### PR TITLE
Custom Rng

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use(s)]
 extern crate ndarray;
+extern crate rand;
 
 #[macro_use]
 #[doc(hidden)]

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,6 +1,7 @@
 extern crate ndarray;
 
-use ndarray_ext::NdArray;
+use ndarray_ext::{NdArray, ArrRng};
+use rand::Rng;
 use tensor::{ArrayLike, Tensor};
 
 mod basic_source_ops;
@@ -1719,81 +1720,129 @@ pub fn scalar(val: f32) -> Tensor
 /// Outputs values sampled from the normal distribution.
 pub fn random_normal<T: ArrayLike>(shape: &T, mean: f64, stddev: f64) -> Tensor
 {
+    random_normal_rng(Default::default(), shape, mean, stddev)
+}
+
+/// Outputs values sampled from the normal distribution.
+pub fn random_normal_rng<T: ArrayLike, R: Rng + 'static>(arr_rng: ArrRng<R>, shape: &T, mean: f64, stddev: f64) -> Tensor
+{
     let shape = shape.as_tensor();
     Tensor::builder()
         .set_input(&shape)
         .set_shape(shape)
-        .build(random_ops::RandomNormal { mean, stddev })
+        .build(random_ops::RandomNormal::new(arr_rng, mean, stddev))
 }
 
 /// Outputs values sampled from the uniform distribution.
 pub fn random_uniform<T: ArrayLike>(shape: &T, min: f64, max: f64) -> Tensor
 {
+    random_uniform_rng(Default::default(), shape, min, max)
+}
+
+/// Outputs values sampled from the uniform distribution.
+pub fn random_uniform_rng<T: ArrayLike, R: Rng + 'static>(arr_rng: ArrRng<R>, shape: &T, min: f64, max: f64) -> Tensor
+{
     let shape = shape.as_tensor();
     Tensor::builder()
         .set_input(&shape)
         .set_shape(shape)
-        .build(random_ops::RandomUniform { min, max })
+        .build(random_ops::RandomUniform::new(arr_rng, min, max))
 }
 
 /// Outputs values sampled from the standard normal distribution.
 pub fn standard_normal<T: ArrayLike>(shape: &T) -> Tensor
 {
+    standard_normal_rng(Default::default(), shape)
+}
+
+/// Outputs values sampled from the standard normal distribution.
+pub fn standard_normal_rng<T: ArrayLike, R: Rng + 'static>(arr_rng: ArrRng<R>, shape: &T) -> Tensor
+{
     let shape = shape.as_tensor();
     Tensor::builder()
         .set_input(&shape)
         .set_shape(shape)
-        .build(random_ops::StandardNormal)
+        .build(random_ops::StandardNormal::new(arr_rng))
 }
 
 /// Outputs values sampled from the standard uniform distribution.
 pub fn standard_uniform<T: ArrayLike>(shape: &T) -> Tensor
 {
+    standard_uniform_rng(Default::default(), shape)
+}
+
+/// Outputs values sampled from the standard uniform distribution.
+pub fn standard_uniform_rng<T: ArrayLike, R: Rng + 'static>(arr_rng: ArrRng<R>, shape: &T) -> Tensor
+{
     let shape = shape.as_tensor();
     Tensor::builder()
         .set_input(&shape)
         .set_shape(shape)
-        .build(random_ops::StandardUniform)
+        .build(random_ops::StandardUniform::new(arr_rng))
 }
 
 /// Outputs values sampled from the bernoulli distribution.
 pub fn bernoulli<T: ArrayLike>(shape: &T, p: f64) -> Tensor
 {
+    bernoulli_rng(Default::default(), shape, p)
+}
+
+/// Outputs values sampled from the bernoulli distribution.
+pub fn bernoulli_rng<T: ArrayLike, R: Rng + 'static>(arr_rng: ArrRng<R>, shape: &T, p: f64) -> Tensor
+{
     let shape = shape.as_tensor();
     Tensor::builder()
         .set_input(&shape)
         .set_shape(shape)
-        .build(random_ops::Bernoulli { p })
+        .build(random_ops::Bernoulli::new(arr_rng, p))
 }
 
 /// Outputs values sampled from the exponential distribution.
 pub fn random_exp<T: ArrayLike>(shape: &T, lambda: f64) -> Tensor
 {
+    random_exp_rng(Default::default(), shape, lambda)
+}
+
+/// Outputs values sampled from the exponential distribution.
+pub fn random_exp_rng<T: ArrayLike, R: Rng + 'static>(arr_rng: ArrRng<R>, shape: &T, lambda: f64) -> Tensor
+{
     let shape = shape.as_tensor();
     Tensor::builder()
         .set_input(&shape)
         .set_shape(shape)
-        .build(random_ops::Exponential { lambda })
+        .build(random_ops::Exponential::new(arr_rng, lambda))
 }
 
 /// Outputs values sampled from the gamma distribution.
 pub fn random_gamma<T: ArrayLike>(shape: &T, shape_param: f64, scale: f64) -> Tensor
 {
-    let shape = shape.as_tensor();
-    Tensor::builder()
-        .set_input(&shape)
-        .set_shape(shape)
-        .build(random_ops::Gamma { shape_param, scale })
+    random_gamma_rng(Default::default(), shape, shape_param, scale)
 }
 
-/// Outputs values sampled from the log-normal distribution.
-pub fn log_normal<T: ArrayLike>(shape: &T, mean: f64, stddev: f64) -> Tensor
+/// Outputs values sampled from the gamma distribution.
+pub fn random_gamma_rng<T: ArrayLike, R: Rng + 'static>(arr_rng: ArrRng<R>, shape: &T, shape_param: f64, scale: f64) -> Tensor
 {
     let shape = shape.as_tensor();
     Tensor::builder()
         .set_input(&shape)
         .set_shape(shape)
-        .build(random_ops::LogNormal { mean, stddev })
+        .build(random_ops::Gamma::new(arr_rng, shape_param, scale))
+}
+
+/// Outputs values sampled from the log-normal distribution.
+pub fn log_normal<T: ArrayLike>(shape: &T, mean: f64, stddev: f64) -> Tensor
+{
+    log_normal_rng(Default::default(), shape, mean, stddev)
+}
+
+/// Outputs values sampled from the log-normal distribution.
+pub fn log_normal_rng<T: ArrayLike, R: Rng + 'static>(arr_rng: ArrRng<R>, shape: &T, mean: f64, stddev: f64) -> Tensor
+{
+    let shape = shape.as_tensor();
+    Tensor::builder()
+        .set_input(&shape)
+        .set_shape(shape)
+        .build(random_ops::LogNormal::new(arr_rng, mean, stddev))
 }
 
 /// Converts `ndarray::Array` to `ag::Tensor`.

--- a/src/ops/random_ops.rs
+++ b/src/ops/random_ops.rs
@@ -1,48 +1,135 @@
 extern crate ndarray;
 
-use ndarray_ext;
+use ndarray_ext::{self, ArrRng};
 use op;
 use tensor::Tensor;
+use rand::Rng;
 
-pub struct StandardNormal;
-
-pub struct StandardUniform;
-
-pub struct RandomUniform
+pub struct StandardNormal<R>
 {
+    pub arr_rng: ArrRng<R>,
+}
+
+impl<R> StandardNormal<R> {
+    pub fn new(arr_rng: ArrRng<R>) -> Self {
+        Self {
+            arr_rng: arr_rng,
+        }
+    }
+}
+
+pub struct StandardUniform<R>
+{
+    pub arr_rng: ArrRng<R>,
+}
+
+impl<R> StandardUniform<R> {
+    pub fn new(arr_rng: ArrRng<R>) -> Self {
+        Self {
+            arr_rng: arr_rng,
+        }
+    }
+}
+
+pub struct RandomUniform<R>
+{
+    pub arr_rng: ArrRng<R>,
     pub max: f64,
     pub min: f64,
 }
 
-pub struct RandomNormal
+impl<R> RandomUniform<R> {
+    pub fn new(arr_rng: ArrRng<R>, min: f64, max: f64) -> Self {
+        Self {
+            arr_rng: arr_rng,
+            max: max,
+            min: min,
+        }
+    }
+}
+
+pub struct RandomNormal<R>
 {
+    pub arr_rng: ArrRng<R>,
     pub mean:   f64,
     pub stddev: f64,
 }
 
-pub struct Bernoulli
+impl<R> RandomNormal<R> {
+    pub fn new(arr_rng: ArrRng<R>, mean: f64, stddev: f64) -> Self {
+        Self {
+            arr_rng: arr_rng,
+            mean: mean,
+            stddev: stddev,
+        }
+    }
+}
+
+pub struct Bernoulli<R>
 {
+    pub arr_rng: ArrRng<R>,
     pub p: f64,
 }
 
-pub struct Exponential
+impl<R> Bernoulli<R> {
+    pub fn new(arr_rng: ArrRng<R>, p: f64) -> Self {
+        Self {
+            arr_rng: arr_rng,
+            p: p,
+        }
+    }
+}
+
+pub struct Exponential<R>
 {
+    pub arr_rng: ArrRng<R>,
     pub lambda: f64,
 }
 
-pub struct LogNormal
+impl<R> Exponential<R> {
+    pub fn new(arr_rng: ArrRng<R>, lambda: f64) -> Self {
+        Self {
+            arr_rng: arr_rng,
+            lambda: lambda,
+        }
+    }
+}
+
+pub struct LogNormal<R>
 {
+    pub arr_rng: ArrRng<R>,
     pub mean:   f64,
     pub stddev: f64,
 }
 
-pub struct Gamma
+impl<R> LogNormal<R> {
+    pub fn new(arr_rng: ArrRng<R>, mean: f64, stddev: f64) -> Self {
+        Self {
+            arr_rng: arr_rng,
+            mean: mean,
+            stddev: stddev,
+        }
+    }
+}
+
+pub struct Gamma<R>
 {
+    pub arr_rng: ArrRng<R>,
     pub shape_param: f64,
     pub scale:       f64,
 }
 
-impl op::Op for RandomNormal
+impl<R> Gamma<R> {
+    pub fn new(arr_rng: ArrRng<R>, shape_param: f64, scale: f64) -> Self {
+        Self {
+            arr_rng: arr_rng,
+            shape_param: shape_param,
+            scale: scale,
+        }
+    }
+}
+
+impl<R: Rng> op::Op for RandomNormal<R>
 {
     fn name(&self) -> &str
     {
@@ -59,7 +146,7 @@ impl op::Op for RandomNormal
         let xs = ctx.grab_inputs();
         let shape = ndarray_ext::arr_to_shape(xs[0]);
         vec![
-            Ok(::ndarray_ext::random_normal(
+            Ok(self.arr_rng.random_normal(
                 shape.as_slice(),
                 self.mean,
                 self.stddev,
@@ -68,7 +155,7 @@ impl op::Op for RandomNormal
     }
 }
 
-impl op::Op for RandomUniform
+impl<R: Rng> op::Op for RandomUniform<R>
 {
     fn name(&self) -> &str
     {
@@ -85,7 +172,7 @@ impl op::Op for RandomUniform
         let xs = ctx.grab_inputs();
         let shape = ndarray_ext::arr_to_shape(xs[0]);
         vec![
-            Ok(::ndarray_ext::random_uniform(
+            Ok(self.arr_rng.random_uniform(
                 shape.as_slice(),
                 self.min,
                 self.max,
@@ -94,7 +181,7 @@ impl op::Op for RandomUniform
     }
 }
 
-impl op::Op for StandardNormal
+impl<R: Rng> op::Op for StandardNormal<R>
 {
     fn name(&self) -> &str
     {
@@ -110,11 +197,11 @@ impl op::Op for StandardNormal
     {
         let xs = ctx.grab_inputs();
         let shape = ndarray_ext::arr_to_shape(xs[0]);
-        vec![Ok(::ndarray_ext::standard_normal(shape.as_slice()))]
+        vec![Ok(self.arr_rng.standard_normal(shape.as_slice()))]
     }
 }
 
-impl op::Op for StandardUniform
+impl<R: Rng> op::Op for StandardUniform<R>
 {
     fn name(&self) -> &str
     {
@@ -130,11 +217,11 @@ impl op::Op for StandardUniform
     {
         let xs = ctx.grab_inputs();
         let shape = ndarray_ext::arr_to_shape(xs[0]);
-        vec![Ok(::ndarray_ext::standard_uniform(shape.as_slice()))]
+        vec![Ok(self.arr_rng.standard_uniform(shape.as_slice()))]
     }
 }
 
-impl op::Op for Bernoulli
+impl<R: Rng> op::Op for Bernoulli<R>
 {
     fn name(&self) -> &str
     {
@@ -150,11 +237,11 @@ impl op::Op for Bernoulli
     {
         let xs = ctx.grab_inputs();
         let shape = ndarray_ext::arr_to_shape(xs[0]);
-        vec![Ok(::ndarray_ext::bernoulli(shape.as_slice(), self.p))]
+        vec![Ok(self.arr_rng.bernoulli(shape.as_slice(), self.p))]
     }
 }
 
-impl op::Op for Exponential
+impl<R: Rng> op::Op for Exponential<R>
 {
     fn name(&self) -> &str
     {
@@ -171,12 +258,12 @@ impl op::Op for Exponential
         let xs = ctx.grab_inputs();
         let shape = ndarray_ext::arr_to_shape(xs[0]);
         vec![
-            Ok(::ndarray_ext::exponential(shape.as_slice(), self.lambda)),
+            Ok(self.arr_rng.exponential(shape.as_slice(), self.lambda)),
         ]
     }
 }
 
-impl op::Op for LogNormal
+impl<R: Rng> op::Op for LogNormal<R>
 {
     fn name(&self) -> &str
     {
@@ -193,7 +280,7 @@ impl op::Op for LogNormal
         let xs = ctx.grab_inputs();
         let shape = ndarray_ext::arr_to_shape(xs[0]);
         vec![
-            Ok(::ndarray_ext::log_normal(
+            Ok(self.arr_rng.log_normal(
                 shape.as_slice(),
                 self.mean,
                 self.stddev,
@@ -202,7 +289,7 @@ impl op::Op for LogNormal
     }
 }
 
-impl op::Op for Gamma
+impl<R: Rng> op::Op for Gamma<R>
 {
     fn name(&self) -> &str
     {
@@ -219,7 +306,7 @@ impl op::Op for Gamma
         let xs = ctx.grab_inputs();
         let shape = ndarray_ext::arr_to_shape(xs[0]);
         vec![
-            Ok(::ndarray_ext::gamma(
+            Ok(self.arr_rng.gamma(
                 shape.as_slice(),
                 self.shape_param,
                 self.scale,


### PR DESCRIPTION
I had an initial pass at https://github.com/raskr/rust-autograd/issues/1 and got this far.

Looking at [src/ops/mod.rs](https://github.com/raskr/rust-autograd/blob/a2a418ee00531181f0f2492d723723c7bfb7cc67/src/ops/mod.rs#L1720), would you like to keep the original function signatures and add new ones? or something else?

```rust
pub fn random_normal_rng<T: ArrayLike, R: Rng + 'static>(shape: &T, mean: f64, stddev: f64, rng: R) -> Tensor
```
