### PR TITLE
Fix argmax index bug when multiple max args

### DIFF
--- a/src/ops/reduction_ops.rs
+++ b/src/ops/reduction_ops.rs
@@ -293,10 +293,15 @@ impl op::Op for ArgMax
             let maxed = x.fold_axis(ndarray::Axis(axis), f32::MIN, move |&a, &b| max_fn(a, b));
             let maxed = ndarray_ext::expand_dims(maxed, axis);
             let mut mask = NdArray::zeros(x.shape());
+            let mut found = false;
             Zip::from(&mut mask)
                 .and(x)
                 .and_broadcast(&maxed)
-                .apply(|r, a, b| *r = ((a == b) as i32) as f32);
+                .apply(|r, a, b| *r = match (found, a == b) {
+                    (true, _) => 0.,
+                    (false, true) => { found = true; 1. },
+                    (false, false) => 0.,
+                });
             mask
         };
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 pub mod test_binary_op_eval;
 pub mod test_binary_op_grad;
+pub mod test_reduction_op_eval;
 pub mod test_tensor_ops_grad;
 pub mod test_array_gen;
 pub mod test_core;

--- a/tests/test_reduction_op_eval.rs
+++ b/tests/test_reduction_op_eval.rs
@@ -1,0 +1,16 @@
+extern crate autograd as ag;
+extern crate ndarray;
+
+#[test]
+fn argmax() {
+    let ref x = ag::constant(ndarray::arr2(&[[3., 4.], [6., 5.]]));
+    let ref y = ag::argmax(x, 1, false);
+    assert_eq!(y.eval(&[]), ndarray::arr1(&[1., 0.]).into_dyn());
+}
+
+#[test]
+fn argmax_with_multi_max_args() {
+    let ref x = ag::constant(ndarray::arr1(&[1., 2., 3., 3.]));
+    let ref y = ag::argmax(x, 0, false);
+    assert_eq!(y.eval(&[]), ndarray::arr0(2.).into_dyn());
+}


### PR DESCRIPTION
Potential fix for https://github.com/raskr/rust-autograd/issues/4. You may be able to come up with a more elegant solution. I am not super familiar with `ndarray`.

This adds a `found` switch, which, when flipped causes the fn in `apply()` to only return `0.`. This ensures we have a maximum of 1.