### PR TITLE
Update to ndarray-0.12 (from ndarray-0.10)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/autograd/"
 
 [dependencies]
 rand = "0.3.15"
-ndarray = { version = "0.10.11" }
+ndarray = { version = "0.12.1" }
 glob = "0.2"
 rayon = "1.0"
 libc = "0.2"

--- a/examples/cnn_mnist.rs
+++ b/examples/cnn_mnist.rs
@@ -74,8 +74,14 @@ fn main() {
             let perm = ag::ndarray_ext::permutation(num_batches) * batch_size as usize;
             for i in perm.into_iter() {
                 let i = *i as isize;
-                let x_batch = x_train.slice(s![i..i + batch_size, .., .., ..]).to_owned();
-                let y_batch = y_train.slice(s![i..i + batch_size, ..]).to_owned();
+                let x_batch = x_train
+                    .slice(s![i..i + batch_size, .., .., ..])
+                    .to_owned()
+                    .into_dyn();
+                let y_batch = y_train
+                    .slice(s![i..i + batch_size, ..])
+                    .to_owned()
+                    .into_dyn();
                 ag::eval(update_ops, &[(&x, &x_batch), (&y, &y_batch)]);
             }
         });

--- a/examples/mlp_mnist.rs
+++ b/examples/mlp_mnist.rs
@@ -66,8 +66,14 @@ fn main() {
                 let update_ops: &[Tensor] = &adam.compute_updates(params, grads);
 
                 let i = *i as isize;
-                let x_batch = x_train.slice(s![i..i + batch_size, ..]).to_owned();
-                let y_batch = y_train.slice(s![i..i + batch_size, ..]).to_owned();
+                let x_batch = x_train
+                    .slice(s![i..i + batch_size, ..])
+                    .to_owned()
+                    .into_dyn();
+                let y_batch = y_train
+                    .slice(s![i..i + batch_size, ..])
+                    .to_owned()
+                    .into_dyn();
                 ag::eval(update_ops, &[(&x, &x_batch), (&y, &y_batch)]);
             }
         });

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1671,8 +1671,8 @@ pub fn slice<T: Float, A: AsRef<Tensor<T>>>(x: A, starts: &[isize], ends: &[isiz
     let starts_ends = starts.iter().zip(ends.iter());
 
     let indices = starts_ends
-        .map(|(s, e)| ndarray::Si(*s, if *e == -1 { None } else { Some(*e) }, 1))
-        .collect::<Vec<ndarray::Si>>();
+        .map(|(s, e)| ndarray::Slice::new(*s, if *e == -1 { None } else { Some(*e) }, 1))
+        .collect::<Vec<ndarray::Slice>>();
 
     let op = array_ops::Slice {
         indices: indices.into_boxed_slice(),


### PR DESCRIPTION
- Update dependency ndarray from 0.10.11 to 0.12.1.
- Change `Slice` op inner type from ndarray-0.10 `Si` to respective
  ndarray-0.12 `Slice`.
- Wrap `Slice` into `SliceInfo` in calls to `slice*()`
    * A maintainer of ndarray (jturner314) [recommends](https://jim.turner.link/pages/ndarray-0.11/)
      that slicing be done with `s![]` where applicable. I don't think it
      is applicable in this use case and I decided to do that wrapping
      instead.
- In examples: cast sliced, constant sized batches into dynamic
  ndarrays with `.into_dyn()`, as the new ndarray-0.12 API seems to require
  that.