### PR TITLE
Fix a bunch of clippy lints

### DIFF
--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -57,8 +57,8 @@ macro_rules! access_grad_info_of {
 
 #[inline]
 fn has_marked_child<T: Float>(parent: &Tensor<T>, path: &Vec<GradInfo<T>>) -> bool {
-    let mut it = parent.get_backprop_inputs().iter();
-    while let Some(child) = it.next() {
+    let it = parent.get_backprop_inputs().iter();
+    for child in it {
         if access_grad_info_of!(child, path).has_gradient {
             return true;
         }
@@ -217,7 +217,7 @@ pub fn symbolic_gradients<T: Float>(
 
     // Prepare a heap with given ys.
     let mut heap = ys
-        .into_iter()
+        .iter()
         .map(|y| y.wrapped())
         .collect::<BinaryHeap<TensorWrapper<T>>>();
 

--- a/src/ndarray_ext.rs
+++ b/src/ndarray_ext.rs
@@ -166,7 +166,7 @@ pub(crate) fn scalar_shape<T: Float>() -> NdArray<T> {
 
 #[inline]
 pub(crate) fn is_scalar_shape(shape: &[usize]) -> bool {
-    shape == &[] || shape == &[0]
+    shape == [] || shape == [0]
 }
 
 #[inline]
@@ -201,14 +201,14 @@ pub mod array_gen {
     use std::cell::RefCell;
     use std::marker::PhantomData;
 
-
     /// Range.
     pub fn range<T: Float>(shape: &[usize]) -> NdArray<T> {
         let prod: usize = shape.iter().product();
         NdArray::<T>::from_shape_vec(
             ndarray::IxDyn(shape),
             (0..prod).map(|a| T::from(a).unwrap()).collect::<Vec<_>>(),
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     /// Internal object to create ndarrays whose elements are random numbers.
@@ -251,7 +251,7 @@ pub mod array_gen {
         where
             I: IndependentSample<f64>,
         {
-            let size: usize = shape.into_iter().cloned().product();
+            let size: usize = shape.iter().cloned().product();
             let mut rng = self.rng.borrow_mut();
             unsafe {
                 let mut buf = Self::alloc(size);
@@ -318,7 +318,7 @@ pub mod array_gen {
         pub fn bernoulli(&self, shape: &[usize], p: f64) -> ndarray::Array<T, ndarray::IxDyn> {
             let dist = rand::distributions::Range::new(0., 1.);
             let mut rng = self.rng.borrow_mut();
-            let size: usize = shape.into_iter().cloned().product();
+            let size: usize = shape.iter().cloned().product();
             unsafe {
                 let mut buf = Self::alloc(size);
                 for i in 0..size {

--- a/src/ops/binary_ops.rs
+++ b/src/ops/binary_ops.rs
@@ -58,12 +58,8 @@ impl<T: Float> op::Op<T> for PreprocessBinOpGrad {
                         // `fold_axis` squashes the axis automatically.
                         let axis = ndarray::Axis(if x_is_scalar { 0 } else { i });
                         let ret = match folded {
-                            Some(ref a) => {
-                                a.fold_axis(axis.clone(), T::zero(), |a, b| a.clone() + b.clone())
-                            }
-                            None => {
-                                gy.fold_axis(axis.clone(), T::zero(), |a, b| a.clone() + b.clone())
-                            }
+                            Some(ref a) => a.fold_axis(axis, T::zero(), |a, b| *a + *b),
+                            None => gy.fold_axis(axis, T::zero(), |a, b| *a + *b),
                         };
                         if x_is_scalar {
                             mem::swap(&mut folded, &mut Some(ret));
@@ -177,7 +173,7 @@ impl<T: Float> op::Op<T> for SubOp {
         let x0 = &xs[0];
         let x1 = &xs[1];
         let shape0: &[usize] = x0.shape();
-        let ret = if shape0 == &[] {
+        let ret = if shape0 == [] {
             // is scalar
             let x0_elem = x0[ndarray::IxDyn(&[])];
             crate::ArrRepr::Owned(x1.map(move |&a| x0_elem - a))
@@ -228,8 +224,8 @@ impl<T: Float> op::Op<T> for DivOp {
         let x1 = &xs[1];
         let shape0: &[usize] = x0.shape();
         let shape1: &[usize] = x1.shape();
-        let is_scalar0 = shape0 == &[] || shape0 == &[0];
-        let is_scalar1 = shape1 == &[] || shape1 == &[1];
+        let is_scalar0 = shape0 == [] || shape0 == [0];
+        let is_scalar1 = shape1 == [] || shape1 == [1];
         let ret = if is_scalar0 {
             // a is a scalar
             let x0_elem = x0[ndarray::IxDyn(&[])];

--- a/src/ops/conv_ops/conv2d.rs
+++ b/src/ops/conv_ops/conv2d.rs
@@ -361,8 +361,7 @@ impl<T: Float> crate::op::Op<T> for Conv2DWithCols {
                 };
                 // fallback: parallel sgemm using rayon
                 (0..batch_size).into_par_iter().for_each(|i| {
-                    let c_region_head =
-                        c_slice.as_ptr().offset((i * size_per_batch_c) as isize) as *const T;
+                    let c_region_head = c_slice.as_ptr().add(i * size_per_batch_c) as *const T;
                     let y_region_head: *mut T = mem::transmute(&y[i * size_per_batch_y]);
                     slow_gemm!(
                         false,
@@ -487,8 +486,8 @@ impl<T: Float> crate::op::Op<T> for Conv2DFilterGrad {
                     slow_gemm!(
                         false,
                         true,
-                        gy.offset((i * size_per_batch_g) as isize) as *const f32,
-                        cols.offset((i * size_per_batch_c) as isize) as *const f32,
+                        gy.add(i * size_per_batch_g) as *const f32,
+                        cols.add(i * size_per_batch_c) as *const f32,
                         gw_head as *mut f32,
                         m,
                         n,

--- a/src/ops/conv_ops/conv2d_transpose.rs
+++ b/src/ops/conv_ops/conv2d_transpose.rs
@@ -116,9 +116,9 @@ impl<T: Float> crate::op::Op<T> for Conv2DTranspose {
                 let size_per_batch_gy = ych * yh * yw;
                 (0..batch_size).into_par_iter().for_each(|i| {
                     let w = w_slice.as_ptr();
-                    let gy_region_head = gy_slice.as_ptr().offset((i * size_per_batch_gy) as isize);
+                    let gy_region_head = gy_slice.as_ptr().add(i * size_per_batch_gy);
                     let col_region_head: *mut T = mem::transmute(col_ref);
-                    let col_region_head = col_region_head.offset((i * size_per_batch_col) as isize);
+                    let col_region_head = col_region_head.add(i * size_per_batch_col);
                     slow_gemm!(
                         true,
                         false,

--- a/src/ops/conv_ops/max_pool2d.rs
+++ b/src/ops/conv_ops/max_pool2d.rs
@@ -63,7 +63,7 @@ macro_rules! impl_max_pool {
                                 let rows = xw * (h + c_base);
                                 for w in w_start..w_end {
                                     let index = w + rows;
-                                    let val = *input.offset(index as isize);
+                                    let val = *input.add(index);
                                     if val > max {
                                         max_i = index;
                                         max = val;

--- a/src/ops/conv_ops/mod.rs
+++ b/src/ops/conv_ops/mod.rs
@@ -172,7 +172,7 @@ fn im2col_batch<T: Float>(
                         }
                     }
                 }
-                x = x.offset(channel_size as isize);
+                x = x.add(channel_size);
             }
         });
         ret

--- a/src/ops/gradient_descent_ops/adam.rs
+++ b/src/ops/gradient_descent_ops/adam.rs
@@ -131,7 +131,7 @@ impl<T: Float> Adam<T> {
     pub fn vars_with_states<'a>(tensors: &[&'a Tensor<T>]) -> Vec<StatefulVariable<'a, T>> {
         let mut var2state = BTreeMap::<super::StateKey<'a, T>, StatefulParams<T>>::new();
         tensors
-            .into_iter()
+            .iter()
             .map(|var| {
                 // let var = var.as_ref();
                 if let Some(var_arr) = var.get_persistent_array() {
@@ -167,7 +167,7 @@ impl<T: Float> Adam<T> {
         grads: &[A],
     ) -> Vec<Tensor<T>> {
         params
-            .into_iter()
+            .iter()
             .zip(grads)
             .map(|(param, grad)| {
                 let StatefulParams { ref m, ref v } = param.state;

--- a/src/ops/gradient_descent_ops/sgd.rs
+++ b/src/ops/gradient_descent_ops/sgd.rs
@@ -56,7 +56,7 @@ impl<'a, T: Float> SGD<T> {
         grads: &[A],
     ) -> Vec<Tensor<T>> {
         params
-            .into_iter()
+            .iter()
             .zip(grads)
             .map(|(param, grad)| {
                 Tensor::builder()

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -94,7 +94,7 @@ where
 {
     let ys = ys
         .iter()
-        .map(|y| crate::ops::reduce_sum_to_scalar(y))
+        .map(crate::ops::reduce_sum_to_scalar)
         .collect::<Vec<_>>();
     let gys = vec![scalar(T::one()); ys.len()];
     unsafe { grad_with_default(&ys, xs, &gys) }

--- a/src/ops/reduction_ops.rs
+++ b/src/ops/reduction_ops.rs
@@ -221,7 +221,7 @@ impl<T: Float> op::Op<T> for ReduceMean {
                 arr.mapv_inplace(move |elem| elem * reduction_len_inv);
                 crate::ArrRepr::Owned(arr)
             }
-            view @ _ => view,
+            view => view,
         };
 
         vec![Ok(ret)]

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -238,7 +238,7 @@ impl<T: Float> TensorBuilder<T> {
 
     #[inline]
     pub fn build<O: op::Op<T> + 'static>(self, op: O) -> Tensor<T> {
-        let rank = if self.inputs.len() == 0 {
+        let rank = if self.inputs.is_empty() {
             0
         } else {
             self.inputs


### PR DESCRIPTION
Work conservatively with clippy to fix some lints.

Working towards lintlessness, but the remainder of the lints have some justification:
- "Too many" single-character variable names in a function.
- Some strange clones and transmutes.
- eval in runtime.rs: "This function has a cognitive complexity of 31" :D