### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -175,7 +175,7 @@ fn test_gradient_path() {
     use std::collections::btree_set::BTreeSet;
     let all = (0..10).collect::<BTreeSet<usize>>();
     let should_be_has_gradient = [ix1, ix2, ia, ic, ib, id, iy]
-        .into_iter()
+        .iter()
         .cloned()
         .collect::<BTreeSet<usize>>();
     for &id in should_be_has_gradient.iter() {


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
