### PR TITLE
Return a value from `with`

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -85,13 +85,13 @@ impl<T: Float> fmt::Debug for Graph<T> {
 /// Creates a scope for a computation graph.
 ///
 /// This is the only way to create [Graph](struct.Graph.html) instances.
-pub fn with<F, FN>(f: FN)
+pub fn with<F, FN, R>(f: FN) -> R
 where
     F: Float,
-    FN: FnOnce(&mut Graph<F>) -> () + Send,
+    FN: FnOnce(&mut Graph<F>) -> R + Send,
 {
     let mut g = Graph {
         node_set: UnsafeCell::new(Vec::with_capacity(128)),
     };
-    f(&mut g);
+    f(&mut g)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ pub use crate::tensor::Tensor;
 
 pub(crate) use crate::ndarray_ext::ArrRepr;
 
-pub use crate::graph::{with, Graph};
+pub use crate::graph::{run, with, Graph};
 
 /// Error during tensor's evaluation.
 #[derive(Debug, PartialEq)]

--- a/src/ops/conv_ops/conv2d_transpose.rs
+++ b/src/ops/conv_ops/conv2d_transpose.rs
@@ -481,7 +481,7 @@ fn test_deconv() {
     )
     .unwrap();
 
-    let out_val = crate::with(|s: &mut crate::Graph<f32>| {
+    let out_val = crate::run(|s: &mut crate::Graph<f32>| {
         let w = s.ones(&[ych, xch, kh, kw]);
         let g = s.ones(&[batch_size, ych, yh, yw]);
         let out = s.conv2d_transpose(g, w, 0, 1);

--- a/src/ops/conv_ops/conv2d_transpose.rs
+++ b/src/ops/conv_ops/conv2d_transpose.rs
@@ -481,11 +481,11 @@ fn test_deconv() {
     )
     .unwrap();
 
-    crate::with::<f32, _>(|s| {
+    let out_val = crate::with(|s: &mut crate::Graph<f32>| {
         let w = s.ones(&[ych, xch, kh, kw]);
         let g = s.ones(&[batch_size, ych, yh, yw]);
         let out = s.conv2d_transpose(g, w, 0, 1);
-        let out_val = out.eval(&[]).unwrap();
-        out_val.all_close(&ans, 1e-3);
+        out.eval(&[]).unwrap()
     });
+    out_val.all_close(&ans, 1e-3);
 }


### PR DESCRIPTION
Thanks for a very cool library! I hope it is OK that I come with an unsolicited PR.

I changed the entry `with` function to return the value of the `FnOnce` it encapsulates. This is an ergonomic win as it allows us to return a value from a `with`-scope like so:

``` rust
let nd_array = autograd::with(|g| {
    let tensor = ...
    tensor.eval(&[])
});
```

I demonstrate its use in `fn test_deconv`.