### PR TITLE
First attempt at moving towards safe code

### DIFF
--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -239,7 +239,7 @@ impl<'t, T: Float> Tensor<'t, T> {
     fn to_node(&'t self) -> Node {
         Node {
             id: self.id,
-            rank: unsafe { self.inner().top_rank },
+            rank: self.inner().top_rank,
         }
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -53,14 +53,18 @@ impl<'t, 'g, F: Float> Graph<F> {
 
     // `i` must be an id returned by Graph::install
     #[inline]
-    pub(crate) unsafe fn access_inner(&self, i: usize) -> &'t TensorInternal<F> {
-        &(*self.node_set.get())[i]
+    pub(crate) fn access_inner(&self, i: usize) -> &'t TensorInternal<F> {
+        unsafe {
+            &(*self.node_set.get())[i]
+        }
     }
 
     // `i` must be an id returned by Graph::install
     #[inline]
-    pub(crate) unsafe fn access_inner_mut(&self, i: usize) -> &'t mut TensorInternal<F> {
-        &mut (*self.node_set.get())[i]
+    pub(crate) fn access_inner_mut(&self, i: usize) -> &'t mut TensorInternal<F> {
+        unsafe {
+            &mut (*self.node_set.get())[i]
+        }
     }
 
     #[inline]

--- a/src/op.rs
+++ b/src/op.rs
@@ -349,19 +349,17 @@ impl<'g, T: Float> GradientContext<'g, T> {
     // Call Op::grad and return `gxs`
     pub(crate) fn extract_input_grads(mut self) -> InputArray<Option<Tensor<'g, T>>> {
         let id = self.y.id;
-        unsafe {
-            // steal op
-            let stolen = mem::replace(&mut self.graph().access_inner_mut(id).op, None).unwrap();
-            // call Op::grad
-            stolen.grad(&mut self);
-            // restore
-            mem::swap(&mut self.graph().access_inner_mut(id).op, &mut Some(stolen));
-            debug_assert!(
-                !self.gxs.is_empty(),
-                "Bad Op impl: GradientContext::set_input_grads was not called"
-            );
-            self.gxs
-        }
+        // steal op
+        let stolen = mem::replace(&mut self.graph().access_inner_mut(id).op, None).unwrap();
+        // call Op::grad
+        stolen.grad(&mut self);
+        // restore
+        mem::swap(&mut self.graph().access_inner_mut(id).op, &mut Some(stolen));
+        debug_assert!(
+            !self.gxs.is_empty(),
+            "Bad Op impl: GradientContext::set_input_grads was not called"
+        );
+        self.gxs
     }
 
     /// Returns the symbolic gradient of the op's output.
@@ -388,7 +386,7 @@ impl<'g, T: Float> GradientContext<'g, T> {
     /// Returns the number of inputs.
     #[inline]
     pub fn num_inputs(&self) -> usize {
-        unsafe { self.y.inner().in_edges.len() }
+        self.y.inner().in_edges.len()
     }
 
     /// Returns a graph object that is usable for tensor computations in the context.

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -93,7 +93,7 @@ impl<'graph, F: Float> crate::graph::Graph<F> {
             ys.push(self.reduce_sum_to_scalar(y));
         }
         let gys = vec![self.scalar(F::one()); len];
-        unsafe { self.grad_with_default(&ys, xs, &gys) }
+        self.grad_with_default(&ys, xs, &gys)
     }
 
     /// Computes `xs`'s gradients with `ys`'s already known gradients.
@@ -111,7 +111,7 @@ impl<'graph, F: Float> crate::graph::Graph<F> {
     ///
     /// # Returns
     /// Symbolic gradient tensors of `xs` in the same order as `xs`'graph.
-    pub unsafe fn grad_with_default<A, B, C>(
+    pub fn grad_with_default<A, B, C>(
         &'graph self,
         ys: &[A],
         xs: &[B],
@@ -279,15 +279,13 @@ impl<'graph, F: Float> crate::graph::Graph<F> {
     where
         A: AsRef<Tensor<'graph, F>> + Copy,
     {
-        unsafe {
-            if let Some(id) = x.as_ref().inner().shape {
-                self.tensor(id)
-            } else {
-                Tensor::builder()
-                    .append_input(x.as_ref())
-                    .set_differentiable(false)
-                    .build(self, array_ops::Shape)
-            }
+        if let Some(id) = x.as_ref().inner().shape {
+            self.tensor(id)
+        } else {
+            Tensor::builder()
+                .append_input(x.as_ref())
+                .set_differentiable(false)
+                .build(self, array_ops::Shape)
         }
     }
 


### PR DESCRIPTION
Tracking unsafe block usage throughout the project I found that unsafes were used for primarily one of two reasons:

1. To avoid lifetime checks on elements of vectors not outliving the vector
2. To mutate interior of data without marking the data as mutable

The first case is probably undesirable though hard to fix. The second case is a perfectly good design pattern which can probably be left alone.

Attached is a first attempt at restraining the number of unsafe blocks in code. Marking these two functions as unsafe doesn't actually prevent any unsafe behavior, so I just moved the unsafe block inside the body of the function. To remove this unsafe code it would be necessary to fix the 1st case of unsafe behaviors, otherwise the borrow checker will complain. With the code as is, the borrow checker watches the magic trick but doesn't know what happened so it accepts the new lifetime after pointer cast.

Any feedback is appreciated.