### PR TITLE
fixed#46

### DIFF
--- a/src/ops/reduction_ops.rs
+++ b/src/ops/reduction_ops.rs
@@ -376,7 +376,9 @@ fn argx_helper<T: Float>(
                 .and(&maxed)
                 .apply(|r, f, m| {
                     let z = r == m && !*f;
-                    *f = z;
+                    if z {
+                        *f = true;
+                    }
                     *r = T::from(z as i32).unwrap();
                 });
         }

--- a/tests/test_tensor_ops_eval.rs
+++ b/tests/test_tensor_ops_eval.rs
@@ -25,6 +25,15 @@ fn argmax() {
 }
 
 #[test]
+fn argmax2() {
+    with(|g| {
+        let test = g.constant(array![84.0, 16.0, 0.04, 85.0, 16.0, 85.0]);
+        let max_dis_index = g.argmax(test, 0, false);
+        assert_eq!(max_dis_index.eval(&[]), Ok(ndarray::arr0(3.).into_dyn()));
+    });
+}
+
+#[test]
 fn argmax_with_multi_max_args() {
     with(|g| {
         let x = g.constant(array![1., 2., 3., 3.]);


### PR DESCRIPTION
The logic in argx_helper was wrong which caused it to mask more than one maximum with 1 in some cases.
For example:
2 2 2 1 1 1
The old code would mask this
1 0 1 0 0 0
because the found value would have been set to false in the second element and then the third could be masked again.