### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -224,12 +224,12 @@ impl<'view, F: Float> OutputStorage<'view, F> {
 
     #[inline]
     fn push_view(&self, view: NdArrayView<'view, F>) -> usize {
-        unsafe {
-            let s = &mut self.inner_mut().view_storage;
+        
+            let s = unsafe { &mut self.inner_mut().view_storage };
             let ret = s.len();
             s.push(view);
             ret
-        }
+        
     }
 
     #[inline]

--- a/src/ndarray_ext.rs
+++ b/src/ndarray_ext.rs
@@ -206,8 +206,8 @@ pub mod array_gen {
         {
             let size: usize = shape.iter().cloned().product();
             let mut rng = self.rng.borrow_mut();
+            let mut buf = Vec::with_capacity(size);
             unsafe {
-                let mut buf = Vec::with_capacity(size);
                 for i in 0..size {
                     *buf.get_unchecked_mut(i) = T::from(dist.sample(&mut *rng)).unwrap();
                 }
@@ -271,15 +271,15 @@ pub mod array_gen {
             let dist = rand_distr::Uniform::new(0., 1.);
             let mut rng = self.rng.borrow_mut();
             let size: usize = shape.iter().cloned().product();
-            unsafe {
+            
                 let mut buf = Vec::with_capacity(size);
                 for i in 0..size {
                     let val = dist.sample(&mut *rng);
-                    *buf.get_unchecked_mut(i) = T::from(i32::from(val < p)).unwrap();
+                    unsafe { *buf.get_unchecked_mut(i) = T::from(i32::from(val < p)).unwrap() };
                 }
-                buf.set_len(size);
+                unsafe { buf.set_len(size) };
                 NdArray::from_shape_vec(shape, buf).unwrap()
-            }
+            
         }
 
         /// Creates an ndarray sampled from the exponential distribution with given params.

--- a/src/tensor_ops/conv_ops/conv2d.rs
+++ b/src/tensor_ops/conv_ops/conv2d.rs
@@ -206,8 +206,8 @@ fn slow_im2col_gemm_fused_kernel<F: Float>(
     unsafe {
         y.set_len(batch_size * y_size_per_batch);
         cols.set_len(batch_size * col_size_per_batch);
-        (y, cols)
     }
+    (y, cols)
 }
 
 #[cfg(feature = "blas")]
@@ -451,7 +451,7 @@ fn conv2d_impl<F: Float>(
         }
     }
 
-    unsafe {
+    
         let f;
         #[cfg(feature = "blas")]
         {
@@ -481,9 +481,9 @@ fn conv2d_impl<F: Float>(
         );
         let y = NdArray::from_shape_vec(IxDyn(&[batch_size, ych, yh, yw]), y).unwrap();
         let cols =
-            NdArray::from_shape_vec_unchecked(IxDyn(&[batch_size, xch, kw, kh, yh, yw]), cols);
+            unsafe { NdArray::from_shape_vec_unchecked(IxDyn(&[batch_size, xch, kw, kh, yh, yw]), cols) };
         Ok((y, cols))
-    }
+    
 }
 
 fn conv2d_with_cols_impl<F: Float>(cols: &NdArrayView<F>, w: &NdArrayView<F>) -> NdArray<F> {


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html